### PR TITLE
Add (temporary) form changes for theses submissions in prep for May 2…

### DIFF
--- a/src/main/java/edu/mit/att/controllers/UserPages.java
+++ b/src/main/java/edu/mit/att/controllers/UserPages.java
@@ -16,11 +16,10 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.env.Environment;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
 import org.springframework.ui.ModelMap;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import org.springframework.web.multipart.MultipartHttpServletRequest;
@@ -31,6 +30,7 @@ import javax.servlet.ServletContext;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
+import javax.validation.Valid;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -260,33 +260,37 @@ public class UserPages {
             model.addAttribute("ssasForm", submissionAgreement);
         }
 
+        model.addAttribute("transferRequest", new TransferRequest());
+
         return "RecordsSubmissionForm";
     }
 
     // ------------------------------------------------------------------------
-    @RequestMapping("/UploadFiles")
+    @RequestMapping(value = "/UploadFiles", method =  RequestMethod.POST)
     public String UploadFiles(
             ModelMap model,
-            @RequestParam(value = "generalRecordsDescription", required = false) String generalRecordsDescription,
-            @RequestParam(value = "startyear", required = false) String startyear,
-            @RequestParam(value = "endyear", required = false) String endyear,
-            @RequestParam(value="department", required = false) String department,
-            @RequestParam(value="theses", required = false) String theses,
-            @RequestParam(value = "degrees", required = false) String degrees,
+            @Valid TransferRequest transferRequest,
+            BindingResult bindingResult,
             HttpSession session
     ) {
+
         LOGGER.log(Level.INFO, "UploadFiles");
+
+        if (bindingResult.hasErrors()) {
+            LOGGER.log(Level.INFO, "Error validating fields for RecordsSubmissionForm Post");
+            return "RecordsSubmissionForm";
+        }
 
         Format format = new Format();
         String avail = format.showavailbytes(env.getRequiredProperty("dropoff.dir"));
         model.addAttribute("avail_bytes", avail);
 
-        session.setAttribute("generalRecordsDescription", generalRecordsDescription);
-        session.setAttribute("startyear", startyear);
-        session.setAttribute("endyear", endyear);
-        session.setAttribute("department", department);
-        session.setAttribute("theses", theses);
-        session.setAttribute("degrees", degrees);
+        session.setAttribute("generalRecordsDescription", transferRequest.getDescription());
+        session.setAttribute("startyear", transferRequest.getStartyear());
+        session.setAttribute("endyear", transferRequest.getEndyear());
+        session.setAttribute("department", transferRequest.getDepartment());
+        session.setAttribute("theses", transferRequest.getTheses());
+        session.setAttribute("degrees", transferRequest.getDegrees());
 
         model.addAttribute("totalmax", env.getRequiredProperty("js.totalmax"));
         model.addAttribute("peruploadmax", env.getRequiredProperty("js.peruploadmax"));

--- a/src/main/java/edu/mit/att/controllers/UserPages.java
+++ b/src/main/java/edu/mit/att/controllers/UserPages.java
@@ -270,6 +270,9 @@ public class UserPages {
             @RequestParam(value = "generalRecordsDescription", required = false) String generalRecordsDescription,
             @RequestParam(value = "startyear", required = false) String startyear,
             @RequestParam(value = "endyear", required = false) String endyear,
+            @RequestParam(value="department", required = false) String department,
+            @RequestParam(value="theses", required = false) String theses,
+            @RequestParam(value = "degrees", required = false) String degrees,
             HttpSession session
     ) {
         LOGGER.log(Level.INFO, "UploadFiles");
@@ -281,6 +284,9 @@ public class UserPages {
         session.setAttribute("generalRecordsDescription", generalRecordsDescription);
         session.setAttribute("startyear", startyear);
         session.setAttribute("endyear", endyear);
+        session.setAttribute("department", department);
+        session.setAttribute("theses", theses);
+        session.setAttribute("degrees", degrees);
 
         model.addAttribute("totalmax", env.getRequiredProperty("js.totalmax"));
         model.addAttribute("peruploadmax", env.getRequiredProperty("js.peruploadmax"));
@@ -312,9 +318,18 @@ public class UserPages {
         //LOGGER.log(Level.INFO, "UploadComplete GET");
 
         String ssaid = (String) session.getAttribute("ssaid");
+        String degrees = (String) session.getAttribute("degrees");
+        String theses = (String) session.getAttribute("theses");
+        String department = (String) session.getAttribute("department");
         //LOGGER.log(Level.INFO, "SSAID: {0}", ssaid);
 
         model.addAttribute("ssaid", ssaid);
+        model.addAttribute("degrees", degrees);
+        model.addAttribute("theses", theses);
+        model.addAttribute("department", department);
+
+
+        LOGGER.log( Level.INFO, "Session var:" + session.getAttribute("degrees") );
 
         return "UploadComplete";
     }
@@ -380,13 +395,18 @@ public class UserPages {
         String username = (String) session.getAttribute("username");
         String useremail = (String) session.getAttribute("email");
 
-
+        final String degrees = (String) session.getAttribute("degrees");
+        final String theses = (String) session.getAttribute("theses");
+        final String department = (String) session.getAttribute("department");
         // Create TransferRequest:
 
         TransferRequest rsa = new TransferRequest();
         rsa.setStartyear(startYear);
         rsa.setEndyear(endYear);
         rsa.setDescription(description);
+        rsa.setDegrees(degrees);
+        rsa.setTheses(theses);
+        rsa.setDepartment(department);
         rsa.setApproved(false);
         rsa.setCreatedby(name); // name here... not username... change?
         final String sqlDate = String.format("%1$tY-%1$tm-%1$td", Calendar.getInstance());
@@ -501,6 +521,12 @@ public class UserPages {
 
                 metadata.put("Effective date for submission agreement ", ssa.getEffectivedate());
                 metadata.put("Retention schedule", ssa.getRetentionschedule());
+
+                // Add theses information
+
+                metadata.put("Degrees (Theses Submission)", degrees);
+                metadata.put("Theses (Theses Submission)", theses);
+                metadata.put("Department (Theses Submission)", department);
 
                 // Creator(s) of the records:
 

--- a/src/main/java/edu/mit/att/entity/TransferRequest.java
+++ b/src/main/java/edu/mit/att/entity/TransferRequest.java
@@ -4,9 +4,11 @@ import org.hibernate.annotations.NotFound;
 import org.hibernate.annotations.NotFoundAction;
 
 import javax.persistence.*;
+import javax.validation.constraints.NotNull;
 import java.util.List;
 
 import lombok.*;
+import org.hibernate.validator.constraints.NotBlank;
 
 @Entity
 @Table(name = "rsas")
@@ -24,9 +26,19 @@ public class TransferRequest {
     private String startyear;
     private String endyear;
     private String description;
+
+    @NotNull
+    @NotBlank
     private String department;
+
+    @NotNull
+    @NotBlank
     private String theses;
+
+    @NotNull
+    @NotBlank
     private String degrees;
+
     private long extent = 0;
     private String extentstr;
     private String transferdate;
@@ -119,6 +131,14 @@ public class TransferRequest {
 
     public void setDegrees(String degrees) {
         this.degrees = degrees;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
     }
 
     @Override

--- a/src/main/java/edu/mit/att/entity/TransferRequest.java
+++ b/src/main/java/edu/mit/att/entity/TransferRequest.java
@@ -24,6 +24,9 @@ public class TransferRequest {
     private String startyear;
     private String endyear;
     private String description;
+    private String department;
+    private String theses;
+    private String degrees;
     private long extent = 0;
     private String extentstr;
     private String transferdate;
@@ -92,6 +95,30 @@ public class TransferRequest {
 
     public void setPath(String path) {
         this.path = path;
+    }
+
+    public String getDepartment() {
+        return department;
+    }
+
+    public void setDepartment(String department) {
+        this.department = department;
+    }
+
+    public String getTheses() {
+        return theses;
+    }
+
+    public void setTheses(String theses) {
+        this.theses = theses;
+    }
+
+    public String getDegrees() {
+        return degrees;
+    }
+
+    public void setDegrees(String degrees) {
+        this.degrees = degrees;
     }
 
     @Override

--- a/src/main/resources/templates/Faq.html
+++ b/src/main/resources/templates/Faq.html
@@ -121,8 +121,8 @@
                     <aside class="content-sup col1q-r" role="complementary">
                         <div id="contact-iasc" class="bit">
                             <h3 class="title">Questions? Contact us.</h3>
-                            <p><a href="mailto:ddc-offers@mit.edu">ddc-offers@mit.edu</a><br />
-                            617.253.5136</p>
+                            <p>Theses: <a href="mailto:mit-theses@mit.edu">mit-theses@mit.edu</a></p>
+                            <p>Other MIT Records: <a href="mailto:ddc-offers@mit.edu">ddc-offers@mit.edu</a></p>
                         </div>
                     </aside>
                 </div>

--- a/src/main/resources/templates/Home.html
+++ b/src/main/resources/templates/Home.html
@@ -33,24 +33,27 @@
                     <div class="col3q">
 
                         <p>The Department of Distinctive Collections (DDC) at MIT Libraries collects, preserves, and makes available digital material as well as paper and other analog formats.</p>
-                        <p>This Digital Transfer Tool provides the ability to transfer digital collections from Institute offices and from student and community organizations to the DDC.</p>
+                        <p>This Digital Transfer Tool provides the ability for you to transfer digital material,
+                            including MIT Theses, from Institute offices to the DDC as the first step to including
+                            them in the Collections.</p>
 
                         <div class="well">
                             <h3 class="hd-4">Get started</h3>
-                            <p>Before you submit your records, please contact the DDC to be sure there is a submission agreement on file.</p>
                             <p><a class="btn button-primary" th:href="@{/SubmitRecords}">Submit records</a></p>
                         </div>
 
                         <hr />
 
                         <h3 class="hd-5">What does the Department of Distinctive Collections (DDC) collect?</h3>
-                        <p>The DDC is interested in:</p>
+                        <p>In alignment with Institute policies and DDC collection development policies:</p>
                         <ul>
                             <li>records that are generated or received by the various administrative and academic offices of the Institute in the conduct of their business, </li>
                             <li>teaching and research materials </li>
                             <li>correspondence with colleagues or professional organizations, </li>
                             <li>committee files</li>
                             <li>financial records (summary level, budgets) and annual reports </li>
+                            <li>MIT Theses</li>
+                            <li>Outreach and promotional material</li>
                             <li>and more...</li>
                         </ul>
 
@@ -63,8 +66,8 @@
                     <aside class="content-sup col1q-r" role="complementary">
                         <div id="contact-iasc" class="bit">
                             <h3 class="title">Questions? Contact us.</h3>
-                            <p><a href="mailto:ddc-offers@mit.edu">ddc-offers@mit.edu</a><br />
-                            617.253.5136</p>
+                            <p>Theses: <a href="mailto:mit-theses@mit.edu">mit-theses@mit.edu</a></p>
+                            <p>Other MIT Records: <a href="mailto:ddc-offers@mit.edu">ddc-offers@mit.edu</a></p>
                         </div>
                     </aside>
 

--- a/src/main/resources/templates/RecordsSubmissionForm.html
+++ b/src/main/resources/templates/RecordsSubmissionForm.html
@@ -51,96 +51,32 @@
                                         </div>
                                     </div>
 
-                                    <h4>Records description</h4>
+                                    <h4>Description (All fields are required)</h4>
                                     <div class="field-wrap">
-                                        <p id="comment-tip">
-                                            You may provide additional information about the history of the records, the person or office that created the records, or any special considerations regarding the records such as comments on copyright or access restrictions.
-                                        </p>
+                                        <label class="field-label" for="department">Department:</label>
+                                        <textarea class="field field-text field-textarea" name="department" cols="40" rows="1"
+                                                  th:text="${department}" aria-describedby="comment-tip"></textarea>
+                                    </div>
 
+                                    <div class="field-wrap">
+                                        <label class="field-label" for="degrees">Degree(s):</label>
+                                        <textarea class="field field-text field-textarea" name="degrees" cols="40" rows="1"
+                                                  th:text="${degrees}" aria-describedby="comment-tip"></textarea>
+                                    </div>
+
+                                    <div class="field-wrap">
+                                        <label class="field-label" for="theses">Number of Theses:</label>
+                                        <textarea class="field field-text field-textarea" name="theses" cols="40" rows="1"
+                                                  th:text="${theses}" aria-describedby="comment-tip"></textarea>
+                                    </div>
+
+
+
+                                    <div class="field-wrap">
                                         <label class="field-label" for="comments">Description or comments (optional):</label>
-
                                         <textarea class="field field-text field-textarea" name="generalRecordsDescription" cols="40" rows="5"
                                             th:text="${generalRecordsDescription}" aria-describedby="comment-tip"></textarea>
                                     </div>
-
-                                    <h4>Submission Agreement information for DLC or Donor</h4>
-
-                                    <p>This is a submission agreement we have on file for your DLC or Donor name that will be automatically added to your submission. If this is not correct, please <a href="#contact-iasc">contact us</a> before submitting your files.</p>
-
-                                    <table class="table copy-sup">
-                                        <tr>
-                                            <th id="ssainfo" valign="top">Effective date for the Submission Agreement</th>
-                                            <td valign="top" th:text="*{ssa.effectivedate}"></td>
-                                        </tr>
-                                        <tr>
-                                            <th valign="top">Retention Schedule</th>
-                                            <td valign="top" th:text="*{ssa.retentionschedule}"></td>
-                                        </tr>
-                                        <tr>
-                                            <th valign="top">Creator(s) of the records</th>
-                                            <td valign="top"><span
-                                                    th:text="'Head of Department/Unit: ' + *{ssa.departmenthead}"></span><br/><span
-                                                    th:text="'Record or Collection Identifier: ' + *{ssa.recordid}"></span>
-                                            </td>
-                                        </tr>
-
-                                        <tr>
-                                            <th valign="top">Person or group authorized to transfer the records to the archives</th>
-                                            <td valign="top">
-                                                <div th:each="item,stat : *{ssa.ssaContactsForms}">
-                                                    <div th:if="${stat.index ne 0}">
-                                                        <hr/>
-                                                    </div>
-                                                    <span th:text="'Name: ' + *{ssa.ssaContactsForms[__${stat.index}__].name}"></span><br/>
-                                                    <span th:text="'Phone Number: ' +  *{ssa.ssaContactsForms[__${stat.index}__].phone}"></span><br/>
-                                                    <span th:text="'Email: ' +  *{ssa.ssaContactsForms[__${stat.index}__].email}"></span><br/>
-                                                    <span th:text="'Campus Address: ' +  *{ssa.ssaContactsForms[__${stat.index}__].address}"></span>
-                                                </div>
-                                            </td>
-                                        </tr>
-
-                                        <tr>
-                                            <th valign="top">Type of records</th>
-                                            <td valign="top" th:text="*{ssa.recordstitle}"></td>
-                                        </tr>
-
-                                        <tr>
-                                            <th valign="top">Copyright and licensing agreement(s)</th>
-                                            <td valign="top">
-                                                <div th:each="item,stat : *{ssa.ssaCopyrightsForms}">
-                                                    <div th:if="${stat.index ne 0}">
-                                                        <hr/>
-                                                    </div>
-                                                    <span th:text="*{ssa.ssaCopyrightsForms[__${stat.index}__].copyright}"></span>
-                                                </div>
-                                            </td>
-                                        </tr>
-
-                                        <tr>
-                                            <th valign="top">Access restrictions</th>
-                                            <td valign="top">
-                                                <div th:switch="*{ssa.ssaAccessRestrictionsForms == null or ssa.ssaAccessRestrictionsForms.size() == 0}">
-                                                    <div th:case="true">
-                                                        None
-                                                    </div>
-                                                    <div th:case="*">
-                                                        <div th:each="item,stat : *{ssa.ssaAccessRestrictionsForms}">
-                                                            <div th:if="${stat.index ne 0}">
-                                                                <hr/>
-                                                            </div>
-                                                            <span th:text="*{ssa.ssaAccessRestrictionsForms[__${stat.index}__].restriction}"></span>
-                                                        </div>
-                                                    </div>
-                                                </div>
-                                            </td>
-                                        </tr>
-
-                                        <tr>
-                                            <th valign="top">Retention period(s)</th>
-                                            <td valign="top" th:text="*{ssa.retentionperiod}"></td>
-                                        </tr>
-
-                                    </table>
 
                                 <!--      <div class="alert_box" id="alert_box_bottom">
                                           <p>Please enter the missing values above.</p>
@@ -156,8 +92,8 @@
                             <aside class="content-sup col1q-r" role="complementary">
                                 <div id="contact-iasc" class="bit">
                                     <h3 class="title">Questions? Contact us.</h3>
-                                    <p><a href="mailto:ddc-offers@mit.edu">ddc-offers@mit.edu</a><br />
-                                    617.253.5136</p>
+                                    <p>Theses: <a href="mailto:mit-theses@mit.edu">mit-theses@mit.edu</a></p>
+                                    <p>Other MIT Records: <a href="mailto:ddc-offers@mit.edu">ddc-offers@mit.edu</a></p>
                                 </div>
                             </aside>
                         </div>

--- a/src/main/resources/templates/RecordsSubmissionForm.html
+++ b/src/main/resources/templates/RecordsSubmissionForm.html
@@ -67,7 +67,7 @@
                                     </div>
 
                                     <div class="field-wrap">
-                                        <label class="field-label" for="comments">Description or comments (optional):</label>
+                                        <label class="field-label" for="generalRecordsDescription">Description or comments (optional):</label>
                                         <textarea class="field field-text field-textarea" id="generalRecordsDescription" cols="40" rows="5"
                                             th:field="*{description}" aria-describedby="comment-tip"></textarea>
                                     </div>

--- a/src/main/resources/templates/RecordsSubmissionForm.html
+++ b/src/main/resources/templates/RecordsSubmissionForm.html
@@ -45,7 +45,7 @@
                                     <h4>Description (All fields are required)</h4>
                                     <div class="field-wrap">
                                         <label name="department" class="field-label" for="department">Department:</label>
-                                        <textarea class="field field-text field-textarea" name="department" cols="40" rows="1"
+                                        <textarea class="field field-text field-textarea" id="department" cols="40" rows="1"
                                                   th:field="*{department}" aria-describedby="comment-tip"></textarea>
                                         <p th:if="${#fields.hasErrors('department')}" th:errors="*{department}"></p>
 
@@ -53,14 +53,14 @@
 
                                     <div class="field-wrap">
                                         <label name="degrees" class="field-label" for="degrees">Degree(s):</label>
-                                        <textarea class="field field-text field-textarea" name="degrees" cols="40" rows="1"
+                                        <textarea class="field field-text field-textarea" id="degrees" cols="40" rows="1"
                                                   th:field="*{degrees}" aria-describedby="comment-tip"></textarea>
                                         <p th:if="${#fields.hasErrors('degrees')}" th:errors="*{degrees}"></p>
                                     </div>
 
                                     <div class="field-wrap">
                                         <label class="field-label" for="theses">Number of Theses:</label>
-                                        <textarea class="field field-text field-textarea" name="theses" cols="40" rows="1"
+                                        <textarea class="field field-text field-textarea" id="theses" cols="40" rows="1"
                                                   th:field="*{theses}" aria-describedby="comment-tip"></textarea>
                                         <p th:if="${#fields.hasErrors('theses')}" th:errors="*{theses}"></p>
 
@@ -68,7 +68,7 @@
 
                                     <div class="field-wrap">
                                         <label class="field-label" for="comments">Description or comments (optional):</label>
-                                        <textarea class="field field-text field-textarea" name="generalRecordsDescription" cols="40" rows="5"
+                                        <textarea class="field field-text field-textarea" id="generalRecordsDescription" cols="40" rows="5"
                                             th:field="*{description}" aria-describedby="comment-tip"></textarea>
                                     </div>
 

--- a/src/main/resources/templates/RecordsSubmissionForm.html
+++ b/src/main/resources/templates/RecordsSubmissionForm.html
@@ -53,13 +53,13 @@
 
                                     <h4>Description (All fields are required)</h4>
                                     <div class="field-wrap">
-                                        <label class="field-label" for="department">Department:</label>
+                                        <label name="department" class="field-label" for="department">Department:</label>
                                         <textarea class="field field-text field-textarea" name="department" cols="40" rows="1"
                                                   th:text="${department}" aria-describedby="comment-tip"></textarea>
                                     </div>
 
                                     <div class="field-wrap">
-                                        <label class="field-label" for="degrees">Degree(s):</label>
+                                        <label name="degrees" class="field-label" for="degrees">Degree(s):</label>
                                         <textarea class="field field-text field-textarea" name="degrees" cols="40" rows="1"
                                                   th:text="${degrees}" aria-describedby="comment-tip"></textarea>
                                     </div>

--- a/src/main/resources/templates/RecordsSubmissionForm.html
+++ b/src/main/resources/templates/RecordsSubmissionForm.html
@@ -28,26 +28,17 @@
 
                                 <h3 class="title-page">Submit Records to the DDC</h3>
 
-                                <div class="alert alert-banner warning" id="alert_box_top">
-                                    <p>The form was not submitted - please correct the fields below:</p>
-                                    <ul>
-                                        <li class="hiddenerror2" id="startyear_error">Beginning Year</li>
-                                        <li class="hiddenerror2" id="endyear_error">Ending Year - enter a valid year or leave blank
-                                        </li>
-                                    </ul>
-                                </div>
-
-                                <form th:action="@{/UploadFiles}" id="form" name="submission" method="post">
+                                <form th:action="@{/UploadFiles}" id="form" name="submission" method="post" th:object="${transferRequest}">
 
                                     <h4>Date span of the records</h4>
                                     <div class="group-inline">
                                         <div class="field-wrap">
                                             <label for="startyear" class="field-label">Beginning year</label> 
-                                            <input class="field field-text" id="startyear" name="startyear" type="text" maxlength="4" size="4" th:value="${startyear}"/>
+                                            <input class="field field-text" id="startyear" name="startyear" type="text" maxlength="4" size="4" th:field="*{startyear}"/>
                                         </div>
                                         <div class="field-wrap">
                                             <label for="endyear" class="field-label">Ending year</label> 
-                                            <input class="field field-text" name="endyear" id="endyear" type="text" maxlength="4" size="4" th:value="${endyear}"/>
+                                            <input class="field field-text" name="endyear" id="endyear" type="text" maxlength="4" size="4" th:field="*{endyear}"/>
                                         </div>
                                     </div>
 
@@ -55,27 +46,30 @@
                                     <div class="field-wrap">
                                         <label name="department" class="field-label" for="department">Department:</label>
                                         <textarea class="field field-text field-textarea" name="department" cols="40" rows="1"
-                                                  th:text="${department}" aria-describedby="comment-tip"></textarea>
+                                                  th:field="*{department}" aria-describedby="comment-tip"></textarea>
+                                        <p th:if="${#fields.hasErrors('department')}" th:errors="*{department}"></p>
+
                                     </div>
 
                                     <div class="field-wrap">
                                         <label name="degrees" class="field-label" for="degrees">Degree(s):</label>
                                         <textarea class="field field-text field-textarea" name="degrees" cols="40" rows="1"
-                                                  th:text="${degrees}" aria-describedby="comment-tip"></textarea>
+                                                  th:field="*{degrees}" aria-describedby="comment-tip"></textarea>
+                                        <p th:if="${#fields.hasErrors('degrees')}" th:errors="*{degrees}"></p>
                                     </div>
 
                                     <div class="field-wrap">
                                         <label class="field-label" for="theses">Number of Theses:</label>
                                         <textarea class="field field-text field-textarea" name="theses" cols="40" rows="1"
-                                                  th:text="${theses}" aria-describedby="comment-tip"></textarea>
+                                                  th:field="*{theses}" aria-describedby="comment-tip"></textarea>
+                                        <p th:if="${#fields.hasErrors('theses')}" th:errors="*{theses}"></p>
+
                                     </div>
-
-
 
                                     <div class="field-wrap">
                                         <label class="field-label" for="comments">Description or comments (optional):</label>
                                         <textarea class="field field-text field-textarea" name="generalRecordsDescription" cols="40" rows="5"
-                                            th:text="${generalRecordsDescription}" aria-describedby="comment-tip"></textarea>
+                                            th:field="*{description}" aria-describedby="comment-tip"></textarea>
                                     </div>
 
                                 <!--      <div class="alert_box" id="alert_box_bottom">

--- a/src/main/resources/templates/RecordsSubmissionForm.html
+++ b/src/main/resources/templates/RecordsSubmissionForm.html
@@ -72,10 +72,6 @@
                                             th:field="*{description}" aria-describedby="comment-tip"></textarea>
                                     </div>
 
-                                <!--      <div class="alert_box" id="alert_box_bottom">
-                                          <p>Please enter the missing values above.</p>
-                                      </div>-->
-
                                     <button type="submit" class="btn button-primary">Next: Select files</button>
          
                                 <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->

--- a/src/main/resources/templates/SubmissionInstructions.html
+++ b/src/main/resources/templates/SubmissionInstructions.html
@@ -32,32 +32,24 @@
 
                             <ol>
                                 <li>Click the <strong> Submit records </strong> button</li>
-                                <li>First, select your DLC or Donor and Record Title so we can match your digital
-                                    material with an existing submission agreement. Don't see your name or DLC on the
-                                    list? Please <a href="mailto:ddc-offers@mit.edu">contact us</a>.</li>
+                                <li>First, select "MIT Thesis 2020" from the dropdown menu below.</li>
                                 <li>Click the <strong> Next: Record details button</strong>.</li>
-                                <li>Record the starting year and end year of the digital material to the best of your
-                                    knowledge. If all of the files are from a single year, record that in the starting
-                                    year and leave the end year blank.</li>
-                                <li>Add a brief description about the history of the material, the person or office
-                                    that created the material, or any special considerations regarding the material
-                                    such as comments on access restrictions.
-                                </li>
-                                <li>
-                                    At the bottom of the page you will see information from your completed
-                                    submission agreement. This will be pre-filled based on prior contact with the
-                                    Department of Distinctive Collections. If it looks incorrect, please <a href="mailto:ddc-offers@mit.edu">contact us</a>.
-                                </li>
+                                <li>Enter the Date span of the records, Department, Degree(s), and Number of Theses.</li>
                                 <li> Once finished, click <strong> Next: Select files </strong>
                                 </li>
                                 <li>Upload your digital content on the Add Digital Content Files page. Click the <strong> Choose
                                     File </strong> button under <strong> Select a file to upload </strong>, which will open your computer’s file browser.
-                                    If you have multiple files or folder(s), you will have to put them into a zip
-                                    folder first. To create a zip folder, follow <a href="https://www.wikihow.com/Make-a-Zip-File">these instructions</a> for PC and OSX.
-                                    If you select the wrong file, you can click <strong> Remove all files </strong> to start over.
+                                    <ul>
+                                        <li>
+                                            If you have multiple files or folder(s), you will have to put them into a zip
+                                            folder first. To create a zip folder, follow <a href="https://www.wikihow.com/Make-a-Zip-File">these instructions</a> for PC and OSX.
+                                        </li>
+                                        <li>Name the zip file DeptProgramName_degree_2020_May_theses.</li>
+                                        <li>If you select the wrong file, you can click <strong> Remove all files </strong> to start over.</li>
+                                    </ul>
                                 </li>
                                 <li> Click the <strong> Submit Query </strong> button to upload your files. As the page notes, this can
-                                    take some time, so please leave the page open while the files upload
+                                    take some time. Do not close your Browser window until the files have completed their upload.
                                 </li>
                                 <li>Once upload is complete, the tool will bring you to the next page and provide a
                                     summary of what you submitted. We will also contact you to confirm the successful
@@ -77,8 +69,8 @@
                     <aside class="content-sup col1q-r" role="complementary">
                         <div id="contact-iasc" class="bit">
                             <h3 class="title">Questions? Contact us.</h3>
-                            <p><a href="mailto:ddc-offers@mit.edu">ddc-offers@mit.edu</a><br />
-                            617.253.5136</p>
+                            <p>Theses: <a href="mailto:mit-theses@mit.edu">mit-theses@mit.edu</a></p>
+                            <p>Other MIT Records: <a href="mailto:ddc-offers@mit.edu">ddc-offers@mit.edu</a></p>
                         </div>
                     </aside>
                 </div>

--- a/src/main/resources/templates/SubmitRecords.html
+++ b/src/main/resources/templates/SubmitRecords.html
@@ -48,8 +48,8 @@
                     <aside class="content-sup col1q-r" role="complementary">
                         <div id="contact-iasc" class="bit">
                             <h3 class="title">Questions? Contact us.</h3>
-                            <p><a href="mailto:ddc-offers@mit.edu">ddc-offers@mit.edu</a><br />
-                            617.253.5136</p>
+                            <p>Theses: <a href="mailto:mit-theses@mit.edu">mit-theses@mit.edu</a></p>
+                            <p>Other MIT Records: <a href="mailto:ddc-offers@mit.edu">ddc-offers@mit.edu</a></p>
                         </div>
                     </aside>
                 </div>

--- a/src/main/resources/templates/UploadComplete.html
+++ b/src/main/resources/templates/UploadComplete.html
@@ -21,14 +21,6 @@
             </div>
 
             <div class="success_box" th:if="${staffemailsent}">
-                <!--<p>
-                    Thank you for your successful completion of a Records
-                    Submission for Submission Agreement ID=<span th:text="${ssaid}"></span> and
-                    Transfer Request ID=<span th:text="${rsaid}"></span>. The Archive staff
-                    has been notified of the submission. The staff will review this transfer and upon
-                    approval will send an email acknowledgement.
-                </p>-->
-
                 <p>
                     Thank you for your successful completion of a Records
                     Submission for Submission Agreement ID=<span th:text="${ssaid}"></span> and

--- a/src/main/resources/templates/UploadFiles.html
+++ b/src/main/resources/templates/UploadFiles.html
@@ -92,7 +92,7 @@
                         <input type="submit" class="btn button-primary" onclick="gatherfiledata_validate_and_submit()">Upload and submit</input>
 -->
 
-                        <input name="submit" type="submit" class="btn button-primary"></input>
+                        <input id="submit" type="submit" class="btn button-primary"></input>
 
 
                     </form>

--- a/src/main/resources/templates/UploadFiles.html
+++ b/src/main/resources/templates/UploadFiles.html
@@ -92,7 +92,7 @@
                         <input type="submit" class="btn button-primary" onclick="gatherfiledata_validate_and_submit()">Upload and submit</input>
 -->
 
-                        <input type="submit" class="btn button-primary"></input>
+                        <input name="submit" type="submit" class="btn button-primary"></input>
 
 
                     </form>

--- a/src/main/resources/templates/UploadFiles.html
+++ b/src/main/resources/templates/UploadFiles.html
@@ -5,7 +5,7 @@
     <meta charset="utf-8"/>
     <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
-    <title>Add Digital Content Files</title>
+    <title>Upload Digital Files</title>
 
     <div th:replace="fragments/header :: header-css"/>
 
@@ -41,7 +41,9 @@
                     <h3 class="title-page">Add Digital Content Files</h3>
 
                     <form method="post" th:action="@{/UploadComplete}" enctype="multipart/form-data" id="form">
-                        <p>Please select the file you would like to upload below. An inventory will be automatically generated for you. Alternatively, you can create and upload an inventory document to submit. </p>
+                        <p>Please select the .zip file you would like to upload below.
+                            Please see the instructions tab if you have any questions related to the creation and naming
+                            of the .zip file. </p>
                         <p class="tip" id="maxuploadsize">The total size of all files to be uploaded must be less than <span th:text="${avail_bytes}"></span>.</p>
 
                         <input type="hidden" name="filedata" id="filedata"/>
@@ -59,6 +61,8 @@
 <!--
                                     <input class="field-upload" type="file" name="file" id="file" multiple="multiple" onchange="gatherdisplayfiledata('1')"/>
 -->
+                                    <p> By transferring theses to the Libraries using this Digital Transfer Tool,
+                                        your department is confirming that the theses have been approved and certified. </p>
 
                                     <input class="field-upload" type="file" name="file" id="file"/>
 
@@ -88,7 +92,7 @@
                         <input type="submit" class="btn button-primary" onclick="gatherfiledata_validate_and_submit()">Upload and submit</input>
 -->
 
-                        <input type="submit" class="btn button-primary">Upload and submit</input>
+                        <input type="submit" class="btn button-primary"></input>
 
 
                     </form>
@@ -101,8 +105,8 @@
                 <aside class="content-sup col1q-r" role="complementary">
                     <div id="contact-iasc" class="bit">
                         <h3 class="title">Questions? Contact us.</h3>
-                        <p><a href="mailto:ddc-offers@mit.edu">ddc-offers@mit.edu</a><br />
-                        617.253.5136</p>
+                        <p>Theses: <a href="mailto:mit-theses@mit.edu">mit-theses@mit.edu</a></p>
+                        <p>Other MIT Records: <a href="mailto:ddc-offers@mit.edu">ddc-offers@mit.edu</a></p>
                     </div>
                 </aside>
             </div>

--- a/src/test/java/edu/mit/att/TransferRequestTest.java
+++ b/src/test/java/edu/mit/att/TransferRequestTest.java
@@ -83,6 +83,9 @@ public class TransferRequestTest {
 
         final TransferRequest transferRequest = new TransferRequest();
         transferRequest.setSubmissionAgreement(submissionAgreement);
+        transferRequest.setDepartment("CSAIL");
+        transferRequest.setTheses("1");
+        transferRequest.setDegrees("BS");
 
         // TODO just use TemporaryFolder
         final Path rootDirectory = FileSystems.getDefault().getPath(temporaryFolder.newFolder().getAbsolutePath());


### PR DESCRIPTION
**1. What is purpose of this PR?**

This commit just adds three fields to the submission form and updates user-facing language.

These changes will be be rollbacked once theses ingest (May 2020) submission is over.

Optional -- Refer to the following docs for details:

https://docs.google.com/document/d/1v2l5s5LQsHR9MvZmKu3-npArQ8k9vlVY2yr1mmStz4E/edit

**2. How to test this PR?**

This is mostly a change to the form used for submission. Three fields are added to the form and the language for the form (and sidebar) was updated according to business owner instructions.

Mikki/Joe will test the language changes.

To test this PR locally, you can just follow the Docker instructions in README.md and follow the steps below.

**Please let me know if you'd like a demo of this over Zoom.**

Here are the instructions:

- First add a dummy submission agreement: http://localhost:8080/att/ListSsas (or under Admin / Create a Submission Agreement)
- Select DLS from the first drop down and just click Submit.
- Browse to: http://localhost:8080/att/SubmitRecords
- Click “next record details”
- Confirm that fields (degree, number of theses, department) appear
- Add some sample information for these fields only (e.g., degree B.S., thesis: 1, department: sail)
- Click on next
- Add a simple file (e.g. a text file)
- Click submit
- Confirm submission is complete
- Browse http://localhost:8080/att/ListDraftRsas (or under Admin / Review Transfer Requests)
- Click on download
- Unzip the file and open att-metadata.txt
- Confirm degree, number of theses, department fields and values are present

Again, these are relatively minor and temporary changes. Mikki and Joe will confirm that the functionality is working as expected.

**3. Related JIRA tickets**

MTS-14

https://mitlibraries.atlassian.net/browse/MTS-14?atlOrigin=eyJpIjoiYzhjYWExODllN2Q5NGVmMmJjNDNkMzdjMWY0MGMzNWMiLCJwIjoiaiJ9

**4. Dependencies**

None
