### PR TITLE
Remove link for admins and file size language from pages.

### DIFF
--- a/src/main/java/edu/mit/att/controllers/RsaAdmin.java
+++ b/src/main/java/edu/mit/att/controllers/RsaAdmin.java
@@ -92,7 +92,7 @@ public class RsaAdmin {
         model.addAttribute("downloadfailed", downloadfailed);
 
         List<TransferRequest> transferRequests = rsarepo.findByApprovedFalseAndDeletedFalseOrderByTransferdateAsc();
-        LOGGER.info("Found requests:" + transferRequests);
+        LOGGER.info("Found requests:" + transferRequests.size());
 
         model.addAttribute(RSAS_FORMS, transferRequests);
 

--- a/src/main/resources/templates/ListDraftRsas.html
+++ b/src/main/resources/templates/ListDraftRsas.html
@@ -145,7 +145,6 @@
                                                     document<span
                                                         th:if="*{transferRequests[__${stat.index}__].rsaFileDataForms.size() != 1}"></span>
                                                     <br/>
-                                                    <a th:href="@{/DownloadZipFile(rsaid=*{transferRequests[__${stat.index}__].id}, redirect='ListDraftRsas')}">Download</a>
                                                     <!--<a th:href="@{/ListDraftFiles(rsaid=*{transferRequests[__${stat.index}__].id})}">&#9632;</a>&nbsp;&nbsp;<a
                                                         th:onclick="*{'return confirm_delete_inventory(' + transferRequests[__${stat.index}__].rsaFileDataForms.size() + ')'}"
                                                         th:href="@{/DeleteDraftInventory(rsaid=*{transferRequests[__${stat.index}__].id})}">Delete</a>-->

--- a/src/main/resources/templates/UploadFiles.html
+++ b/src/main/resources/templates/UploadFiles.html
@@ -44,8 +44,6 @@
                         <p>Please select the .zip file you would like to upload below.
                             Please see the instructions tab if you have any questions related to the creation and naming
                             of the .zip file. </p>
-                        <p class="tip" id="maxuploadsize">The total size of all files to be uploaded must be less than <span th:text="${avail_bytes}"></span>.</p>
-
                         <input type="hidden" name="filedata" id="filedata"/>
                         <input name="file_counter" type="hidden" value="1" id="file_counter"/>
                         <input name="havail_bytes" type="hidden" value="empty" id="havail_bytes"/>


### PR DESCRIPTION
**1. What is this PR?**

This PR temporarily disables certain UI element per stakeholder instructions. It also disables the download link from within the application since this feature is not needed (admins access files via the share) and since we have not tested it thoroughly. These are temporary changes and will be rolled back after thesis ingest phase.

**2. How to test this?**

These changes have been tested by stakeholder. For developer testing build as usual and confirm that the two elements that have been removed do not appear. 

**3. Related tickets:**

https://mitlibraries.atlassian.net/browse/MTS-30 for file size language

**4. Dependencies:**

None